### PR TITLE
add config overlay for biometric sensors

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -400,4 +400,13 @@
 
     <!-- Enable CBRS support -->
     <bool translatable="false" name="config_cbrs_supported">true</bool>
+
+    <!-- List of biometric sensors on the device, in decreasing strength. Consumed by AuthService
+         when registering authenticators with BiometricService. Format must be ID:Modality:Strength,
+         where: IDs are unique per device, Modality as defined in BiometricAuthenticator.java,
+         and Strength as defined in Authenticators.java -->
+    <string-array name="config_biometric_sensors" translatable="false" >
+        <!-- ID0:Fingerprint:Strong -->
+        <item>0:2:15</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
Related to GrapheneOS/os_issue_tracker#325 and GrapheneOS/os_issue_tracker#326

0:2:15 is the value found in the product overlays for the crosshatch and blueline factory images. However, I don't have either of those devices, so this hasn't been tested to see if they fix the linked issues.